### PR TITLE
remove taxset

### DIFF
--- a/export-nexus.py
+++ b/export-nexus.py
@@ -63,7 +63,6 @@ for idx in part:
 commands = [
     "set autoclose=yes nowarn=yes;",
     "lset coding=noabsencesites rates=gamma;",
-    "taxset MinGroup = FuzhouMin XiamenMin;",
     "prset clockratepr=exponential(3e5);",
     "prset treeagepr = uniform(1.5, 2.5);",
     "prset sampleprob=0.2 samplestrat=random speciationpr=exp(1);",


### PR DESCRIPTION
I realized that we have all the DensiTree and full trees from the last run (the experiment used by the manuscript). So I pushed only the change to the export nexus file. 